### PR TITLE
Fix GitHub Actions workflow for prebuilt deployment

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -30,15 +30,15 @@ jobs:
         
       - name: Run linting
         run: npm run lint
-      
-      - name: Build Next.js application
-        run: npm run build
         
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      
+      - name: Build with Vercel
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
       
       - name: Deploy to Vercel (Preview)
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
@@ -63,15 +63,15 @@ jobs:
         
       - name: Run linting
         run: npm run lint
-      
-      - name: Build Next.js application
-        run: npm run build
         
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      
+      - name: Build with Vercel
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       
       - name: Deploy to Vercel (Production)
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
- Use 'vercel build' instead of 'npm run build' to generate proper .vercel/output structure
- Keep quality checks (linting, tests) before build
- Vercel build creates the correct format for --prebuilt deployment
- Fixes "no prebuilt output found in .vercel/output" error

🤖 Generated with [Claude Code](https://claude.ai/code)